### PR TITLE
Add PaymentModal with simple validators

### DIFF
--- a/src/helpers/paymentValidators.helpers.js
+++ b/src/helpers/paymentValidators.helpers.js
@@ -1,0 +1,60 @@
+/**
+ * Helpers de validación ficticia para la pasarela de pago.
+ */
+
+// Validar número de tarjeta (16 dígitos)
+export function isValidCardNumber(input) {
+	if (!input) return false;
+
+	const normalized = String(input).replace(/\s+/g, "");
+
+	if (normalized.length !== 16) return false;
+
+	return !isNaN(normalized);
+}
+
+// Validar fecha de expiración en formato MM/AA (ficticio)
+export function isValidExpiry(input) {
+	if (!input) return false;
+
+	const parts = input.split("/");
+	if (parts.length !== 2) return false;
+
+	const month = parseInt(parts[0], 10);
+	const year = parseInt(parts[1], 10);
+
+	if (isNaN(month) || month < 1 || month > 12) return false;
+
+	if (isNaN(year) || parts[1].length !== 2) return false;
+
+	return true;
+}
+
+// Validar CVV (3 dígitos)
+export function isValidCVV(input) {
+	if (!input) return false;
+
+	const normalized = String(input).trim();
+
+	if (normalized.length !== 3) return false;
+	if (isNaN(normalized)) return false;
+
+	return true;
+}
+
+// Validar titular de la tarjeta (mínimo 3 letras)
+export function isValidHolder(input) {
+	if (!input) return false;
+
+	const normalized = String(input).trim();
+	return normalized.length >= 3;
+}
+
+// Validar email de PayPal
+export function isValidEmail(input) {
+	if (!input) return false;
+
+	const normalized = String(input).trim();
+
+	return normalized.includes("@") && normalized.includes(".");
+}

--- a/src/landing/components/PaymentModal.jsx
+++ b/src/landing/components/PaymentModal.jsx
@@ -1,0 +1,178 @@
+import { useState } from "react";
+import {
+	isValidCardNumber,
+	isValidExpiry,
+	isValidCVV,
+	isValidHolder,
+	isValidEmail,
+} from "../../helpers/paymentValidators.helpers";
+
+const inputClass = "w-full px-3 py-2 border rounded-lg focus:ring focus:ring-blue-300"
+const buttonClass = "px-4 py-2 bg-primary-hover text-white rounded-lg hover:bg-primary-pressed";
+
+export const PaymentModal = ({ isOpen, onClose, onSuccess, paymentMethod }) => {
+	const [processing, setProcessing] = useState(false);
+	const [error, setError] = useState("");
+	const [form, setForm] = useState({
+		cardNumber: "",
+		expiry: "",
+		cvv: "",
+		holder: "",
+		paypalEmail: "",
+	});
+
+	if (!isOpen) return null;
+
+	const handleChange = (event) => {
+		const { name, value } = event.target;
+		setForm({ ...form, [name]: value });
+		setError("");
+	};
+
+	const validate = () => {
+		if (paymentMethod === "credit_card") {
+			if (!isValidCardNumber(form.cardNumber)) return "Número de tarjeta inválido";
+			if (!isValidExpiry(form.expiry)) return "Fecha inválida (usa MM/AA)";
+			if (!isValidCVV(form.cvv)) return "CVV inválido";
+			if (!isValidHolder(form.holder)) return "Titular inválido";
+		}
+
+		if (paymentMethod === "paypal") {
+			if (!isValidEmail(form.paypalEmail)) return "Correo PayPal inválido";
+		}
+
+		return null;
+	};
+
+	const handlePayment = () => {
+		const validationError = validate();
+		if (validationError) {
+			setError(validationError);
+			return;
+		}
+
+		setProcessing(true);
+
+		// Simulación ficticia
+		setTimeout(() => {
+			setProcessing(false);
+			if (Math.random() > 0.2) {
+				onSuccess();
+			} else {
+				alert("❌ Error en el pago simulado. Intenta de nuevo.");
+				onClose();
+			}
+		}, 2000);
+	};
+
+	// --- Render contenido ---
+	let content;
+
+	if (processing) {
+		content = (
+			<div className="flex flex-col items-center justify-center py-6">
+				<div className="animate-spin h-10 w-10 border-4 border-primary-pressed border-t-transparent rounded-full mb-4"></div>
+				<p className="text-gray-600">Procesando pago...</p>
+			</div>
+		);
+	} else {
+		if (paymentMethod === "credit_card") {
+			content = (
+				<div className="flex flex-col gap-4">
+					<input
+						type="text"
+						name="cardNumber"
+						value={form.cardNumber}
+						onChange={handleChange}
+						placeholder="Número de tarjeta (16 dígitos)"
+						className={inputClass}
+					/>
+					<div className="flex gap-3">
+						<input
+							type="text"
+							name="expiry"
+							value={form.expiry}
+							onChange={handleChange}
+							placeholder="MM/AA"
+							className={inputClass}
+						/>
+						<input
+							type="text"
+							name="cvv"
+							value={form.cvv}
+							onChange={handleChange}
+							placeholder="CVV"
+							className={inputClass}
+						/>
+					</div>
+					<input
+						type="text"
+						name="holder"
+						value={form.holder}
+						onChange={handleChange}
+						placeholder="Titular de la tarjeta"
+						className={inputClass}
+					/>
+
+					{error && <p className="text-red-600 text-sm">{error}</p>}
+
+					<div className="flex justify-end gap-3 mt-4">
+						<button
+							onClick={onClose}
+							className="px-4 py-2 bg-gray-200 rounded-lg hover:bg-gray-300"
+						>
+							Cancelar
+						</button>
+						<button
+							onClick={handlePayment}
+							className={buttonClass}
+						>
+							Pagar ahora
+						</button>
+					</div>
+				</div>
+			);
+		} else {
+			content = (
+				<div className="space-y-4">
+					<input
+						type="email"
+						name="paypalEmail"
+						value={form.paypalEmail}
+						onChange={handleChange}
+						placeholder="Correo de PayPal"
+						className={inputClass}
+					/>
+
+					{error && <p className="text-red-600 text-sm">{error}</p>}
+
+					<div className="flex justify-end gap-3 mt-4">
+						<button
+							onClick={onClose}
+							className="px-4 py-2 bg-gray-200 rounded-lg hover:bg-gray-300"
+						>
+							Cancelar
+						</button>
+						<button
+							onClick={handlePayment}
+							className={buttonClass}
+						>
+							Pagar ahora
+						</button>
+					</div>
+				</div>
+			);
+		}
+	}
+
+	return (
+		<div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 px-4">
+			<div className="bg-white w-[350px] max-w-[1290px] rounded-2xl shadow-lg p-4">
+				<h4 className="text-center font-semibold mb-6 text-gray-800">
+					Pago con {paymentMethod === "paypal" ? "PayPal" : "Tarjeta de crédito"}
+				</h4>
+				{content}
+			</div>
+		</div>
+	);
+};

--- a/src/landing/components/ProccesingModal.jsx
+++ b/src/landing/components/ProccesingModal.jsx
@@ -1,0 +1,31 @@
+export const ProcessingModal = ({ isOpen }) => {
+	if (!isOpen) return null;
+
+	return (
+		<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+			<div className="bg-white rounded-2xl shadow-lg p-8 flex flex-col items-center">
+				<svg
+					className="animate-spin h-10 w-10 text-primary-pressed mb-4"
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+				>
+					<circle
+						className="opacity-25"
+						cx="12"
+						cy="12"
+						r="10"
+						stroke="currentColor"
+						strokeWidth="4"
+					></circle>
+					<path
+						className="opacity-75"
+						fill="currentColor"
+						d="M4 12a8 8 0 018-8v4l3-3-3-3v4a12 12 0 00-12 12h4z"
+					></path>
+				</svg>
+				<p className="text-lg font-semibold text-gray-700">Procesando...</p>
+			</div>
+		</div>
+	);
+};

--- a/src/landing/pages/Checkout.jsx
+++ b/src/landing/pages/Checkout.jsx
@@ -4,6 +4,7 @@ import { useContext, useState } from "react";
 import { AuthContext } from "../../contexts/AuthContext.jsx";
 import { calculateSubtotal, calculateTax, toCurrency } from "../../helpers/orders.helpers.js";
 import { LoadingButton } from "../components/LoadingButton.jsx";
+import { PaymentModal } from "../components/PaymentModal.jsx";
 
 export const Checkout = () => {
 	const { items, clearCart } = useCart();
@@ -13,13 +14,22 @@ export const Checkout = () => {
 	const [shippingAddress, setShippingAddress] = useState("");
 	const [billingAddress, setBillingAddress] = useState("");
 	const [paymentMethod, setPaymentMethod] = useState("credit_card");
+
+	const [showPayment, setShowPayment] = useState(false);
 	const [loading, setLoading] = useState(false);
 
 	const subtotal = calculateSubtotal(items);
 	const tax = calculateTax(subtotal);
 	const total = subtotal + tax;
 
-	const handleConfirm = async () => {
+	const handlePaymentSuccess = async () => {
+		setShowPayment(false);
+
+		if (!user) {
+			alert("Debes iniciar sesión para confirmar tu pedido");
+			return;
+		}
+
 		try {
 			setLoading(true);
 			const order = await createOrder(user.id, items, {
@@ -28,20 +38,38 @@ export const Checkout = () => {
 				paymentMethod,
 			});
 
-			// alert("Pedido confirmado con éxito");
+			alert("✅ Pedido confirmado con éxito");
 			console.log("Pedido creado:", order);
 
 			clearCart();
 		} catch (error) {
-			console.error("Error al crear pedido:", error);
-			console.error("Detalle backend:", error.response?.data);
+			console.error("❌ Error al crear pedido:", error);
+			console.error("📡 Backend:", error.response?.data);
+			alert("Hubo un error al confirmar el pedido.");
 		} finally {
 			setLoading(false);
 		}
 	};
 
+	const handleConfirm = () => {
+		if (!user) {
+			alert("Debes iniciar sesión para confirmar tu pedido");
+			return;
+		}
+
+		setShowPayment(true);
+	};
+
 	return (
 		<div className="min-h-screen bg-gray-50 py-10 px-4">
+			{/* Modal de pago ficticio */}
+			<PaymentModal
+				isOpen={showPayment}
+				onClose={() => setShowPayment(false)}
+				onSuccess={handlePaymentSuccess}
+				paymentMethod={paymentMethod}
+			/>
+
 			<div className="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-8">
 				{/* Resumen de productos */}
 				<div className="md:col-span-2 bg-white shadow-md rounded-xl p-6 space-y-4">
@@ -62,7 +90,7 @@ export const Checkout = () => {
 
 				{/* Formulario */}
 				<div className="bg-white shadow-md rounded-xl p-6 space-y-4">
-					<h2 className="text-xl font-bold text-primary-pressed">Datos de envío</h2>
+					<h2 className="font-title text-xl font-bold text-primary-pressed">Datos de envío</h2>
 
 					<div className="space-y-3">
 						<div>
@@ -70,7 +98,7 @@ export const Checkout = () => {
 							<input
 								type="text"
 								value={shippingAddress}
-								onChange={(e) => setShippingAddress(e.target.value)}
+								onChange={(event) => setShippingAddress(event.target.value)}
 								placeholder="Calle Ejemplo, Nº 123"
 								className="w-full px-3 py-2 border rounded-lg"
 							/>
@@ -80,7 +108,7 @@ export const Checkout = () => {
 							<input
 								type="text"
 								value={billingAddress}
-								onChange={(e) => setBillingAddress(e.target.value)}
+								onChange={(event) => setBillingAddress(event.target.value)}
 								placeholder="Calle Ejemplo, Nº 123"
 								className="w-full px-3 py-2 border rounded-lg"
 							/>
@@ -89,7 +117,7 @@ export const Checkout = () => {
 							<label className="block text-sm font-medium">Método de pago</label>
 							<select
 								value={paymentMethod}
-								onChange={(e) => setPaymentMethod(e.target.value)}
+								onChange={(event) => setPaymentMethod(event.target.value)}
 								className="w-full px-3 py-2 border rounded-lg"
 							>
 								<option value="credit_card">Tarjeta de crédito</option>


### PR DESCRIPTION
# What's new?
- Added paymentValidators.helpers.js with basic validations (card, CVV, expiry, holder, email)
- Implemented PaymentModal component with credit card and PayPal simulation
- Integrated PaymentModal flow into Checkout (opens modal before order creation)
- Fixed modal width (replaced md:w-[120px] with max-w-md for proper sizing)
<img width="601" height="490" alt="image" src="https://github.com/user-attachments/assets/6693aa93-8e41-4f2d-a875-abe488be529d" />
